### PR TITLE
Moved intermediate factor out of sum in VE

### DIFF
--- a/docs/lectures/week_5.md
+++ b/docs/lectures/week_5.md
@@ -118,8 +118,10 @@ p(x_1 | \bar x_6) = \frac{p(x_1, \bar x_6)}{p(\bar x_6)} =  \frac{p(x_1, \bar x_
 to compute \(p(x_1, \bar x_6)\), we use variable elimination
 
 \[
-p(x_1, \bar x_6) = p(x_1) \sum_{x_2} \sum_{x_3} \sum_{x_4} \sum_{x_5} p(x_2 | x_1)p(x_3 | x_1)p(x_4 | x_2)p(x_5 | x_3)p(\bar x_6 | x_2, x_5) \\
+p(x_1, \bar x_6) = p(x_1) \sum_{x_2} \sum_{x_3} \sum_{x_4} \sum_{x_5} p(x_2 | x_1)p(x_3 | x_1)p(x_4 | x_2)p(x_5 | x_3)p(\bar x_6 | x_2, x_5)\\
+= p(x_1) \sum_{x_2} p(x_2 | x_1) \sum_{x_3} p(x_3 | x_1) \sum_{x_4} p(x_4 | x_2) \sum_{x_5} p(x_5 | x_3)p(\bar x_6 | x_2, x_5) \\
 = p(x_1)  \sum_{x_2} p(x_2 | x_1) \sum_{x_3} p(x_3 | x_1) \sum_{x_4} p(x_4 | x_2) p(\bar x_6 | x_2, x_3) \\
+= p(x_1)  \sum_{x_2} p(x_2 | x_1) \sum_{x_3} p(x_3 | x_1) p(\bar x_6 | x_2, x_3) \sum_{x_4} p(x_4 | x_2)  \\
 = p(x_1) \sum_{x_2} p(x_2 | x_1) \sum_{x_3} p(x_3 | x_1) p(\bar x_6 | x_2, x_3) \\
 = p(x_1) \sum_{x_2} p(x_2 | x_1) p(\bar x_6 | x_1, x_2) \\
 = p(x_1) p(\bar x_6 | x_1) \\


### PR DESCRIPTION
The optimal variable elimination sum would move the intermediate factors outside of sums over variables not contained in the factors' scope. 
Here this means moving `p(\bar x_6 | x_2, x_3)`, which is the intermediate factor resulting from summing over `x_5`, out of the `\sum{x_4}`.
I also added a line showing how the sums were pushed into the product, before summing out `x_5`, whereas before you (or maybe I) did this both in a single line.